### PR TITLE
Allow non-unique in-buffer settings

### DIFF
--- a/packages/orga/src/processors/keyword.js
+++ b/packages/orga/src/processors/keyword.js
@@ -21,7 +21,9 @@ function process(token, section) {
     break
   default:
     if (section.type === `root`) {
-      section.meta[key.toLowerCase()] = value
+      let field = key.toLowerCase()
+      if (!section.meta[field]) section.meta[field] = [];
+      section.meta[field].push(value)
     }
     break
   }

--- a/packages/orga/src/processors/keyword.js
+++ b/packages/orga/src/processors/keyword.js
@@ -22,8 +22,17 @@ function process(token, section) {
   default:
     if (section.type === `root`) {
       let field = key.toLowerCase()
-      if (!section.meta[field]) section.meta[field] = [];
-      section.meta[field].push(value)
+        if (!section.meta[field]) {
+          section.meta[field] = value;
+        }
+        else {
+          if (!Array.isArray(section.meta[field])) {
+            let list = [];
+            list.push(section.meta[field])
+            section.meta[field] = list
+          }
+          section.meta[field].push(value)
+        }
     }
     break
   }


### PR DESCRIPTION
Changes the meta keys to use an array to allow non-unique Org in-buffer settings if more than one element is present.  This will resolve #8.